### PR TITLE
Refactor units

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+bit-vec = "0.6"
 parking_lot = "0.11.1"
 futures = "0.3.9"
 tokio = { version = "0.2.21", features = ["macros", "rt-threaded", "sync", "time"] }

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -199,11 +199,11 @@ mod tests {
         let bad_pu = PreUnit::<Hasher64>::new(1.into(), 0, control_hash);
         let bad_control_hash: <Hasher64 as Hasher>::Hash = [0, 1, 0, 1, 0, 1, 0, 1];
         assert!(
-            bad_control_hash != bad_pu.control_hash().hash,
+            bad_control_hash != bad_pu.control_hash().combined_hash,
             "Bad control hash cannot be the correct one."
         );
         let mut control_hash = bad_pu.control_hash().clone();
-        control_hash.hash = bad_control_hash;
+        control_hash.combined_hash = bad_control_hash;
         let bad_pu = PreUnit::new(bad_pu.creator(), bad_pu.round(), control_hash);
         let bad_hash: <Hasher64 as Hasher>::Hash = [0, 1, 0, 1, 0, 1, 0, 1];
         let bad_unit = Unit::new(bad_pu, bad_hash);

--- a/src/consensus.rs
+++ b/src/consensus.rs
@@ -90,7 +90,7 @@ mod tests {
     use super::*;
     use crate::{
         testing::mock::{Hasher64, HonestHub},
-        units::{PreUnit, Unit},
+        units::{ControlHash, PreUnit, Unit},
         NodeIndex,
     };
     use futures::{channel, sink::SinkExt, stream::StreamExt, Future};
@@ -195,16 +195,18 @@ mod tests {
             "consensus",
             run(conf, rx_in, tx_out, batch_tx, spawner.clone(), exit_rx),
         );
-        let mut bad_pu =
-            PreUnit::<Hasher64>::new_from_parents(1.into(), 0, (vec![None; n_nodes]).into());
+        let control_hash = ControlHash::new(&(vec![None; n_nodes]).into());
+        let bad_pu = PreUnit::<Hasher64>::new(1.into(), 0, control_hash);
         let bad_control_hash: <Hasher64 as Hasher>::Hash = [0, 1, 0, 1, 0, 1, 0, 1];
         assert!(
-            bad_control_hash != bad_pu.control_hash.hash,
+            bad_control_hash != bad_pu.control_hash().hash,
             "Bad control hash cannot be the correct one."
         );
-        bad_pu.control_hash.hash = bad_control_hash;
+        let mut control_hash = bad_pu.control_hash().clone();
+        control_hash.hash = bad_control_hash;
+        let bad_pu = PreUnit::new(bad_pu.creator(), bad_pu.round(), control_hash);
         let bad_hash: <Hasher64 as Hasher>::Hash = [0, 1, 0, 1, 0, 1, 0, 1];
-        let bad_unit = Unit::new_from_preunit(bad_pu, bad_hash);
+        let bad_unit = Unit::new(bad_pu, bad_hash);
         let _ = tx_in.send(NotificationIn::NewUnits(vec![bad_unit])).await;
         loop {
             let notification = rx_out.next().await.unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,17 @@ pub trait Index {
 /// A hasher, used for creating identifiers for blocks or units.
 pub trait Hasher: Eq + Clone + Send + Sync + Debug + 'static {
     /// A hash, as an identifier for a block or unit.
-    type Hash: AsRef<[u8]> + Eq + Ord + Copy + Clone + Send + Debug + StdHash + Encode + Decode;
+    type Hash: AsRef<[u8]>
+        + Eq
+        + Ord
+        + Copy
+        + Clone
+        + Send
+        + Debug
+        + StdHash
+        + Encode
+        + Decode
+        + Default;
 
     fn hash(s: &[u8]) -> Self::Hash;
 }

--- a/src/member.rs
+++ b/src/member.rs
@@ -447,15 +447,11 @@ where
         let (u_round, u_control_hash, parent_ids) = match self.store.unit_by_hash(&u_hash) {
             Some(su) => {
                 let full_unit = su.as_signable();
-                let parents = &full_unit.control_hash().parents_mask;
-                let parents = (0..parents.len()).into_iter().map(|i| parents[i]);
+                let parents: Vec<_> = full_unit.control_hash().parents().collect();
                 (
                     full_unit.round(),
-                    full_unit.control_hash().hash,
-                    parents
-                        .enumerate()
-                        .filter_map(|(i, b)| if b { Some(i.into()) } else { None })
-                        .collect::<Vec<NodeIndex>>(),
+                    full_unit.control_hash().combined_hash,
+                    parents,
                 )
             }
             None => {

--- a/src/member.rs
+++ b/src/member.rs
@@ -166,11 +166,7 @@ where
     fn on_create(&mut self, u: PreUnit<H>) {
         debug!(target: "rush-member", "On create notification.");
         let data = self.data_io.get_data();
-        let full_unit = FullUnit {
-            inner: u,
-            data,
-            session_id: self.config.session_id,
-        };
+        let full_unit = FullUnit::new(u, data, self.config.session_id);
         let hash = full_unit.hash();
         // TODO: beware: sign_unit blocks and is quite slow!
         let signed_unit = Signed::sign(self.keybox, full_unit);
@@ -312,7 +308,7 @@ where
     fn validate_unit_parents(&self, su: &SignedUnit<'a, H, D, KB>) -> bool {
         // NOTE: at this point we cannot validate correctness of the control hash, in principle it could be
         // just a random hash, but we still would not be able to deduce that by looking at the unit only.
-        let pre_unit = &su.as_signable().inner;
+        let pre_unit = su.as_signable().as_pre_unit();
         if pre_unit.n_members() != self.config.n_members {
             debug!(target: "rush-member", "Unit with wrong length of parents map.");
             return false;
@@ -328,8 +324,8 @@ where
             debug!(target: "rush-member", "Unit of non-zero round with only {:?} parents while at least {:?} are required.", n_parents, threshold);
             return false;
         }
-        let control_hash = &pre_unit.control_hash;
-        if round > 0 && !control_hash.parents[pre_unit.creator()] {
+        let control_hash = &pre_unit.control_hash();
+        if round > 0 && !control_hash.parents_mask[pre_unit.creator().0] {
             debug!(target: "rush-member", "Unit does not have its creator's previous unit as parent.");
             return false;
         }
@@ -341,7 +337,7 @@ where
         // TODO: consider moving validation logic for units and alerts to another file, note however
         // that access to the authority list is required for validation.
         let full_unit = su.as_signable();
-        if full_unit.session_id != self.config.session_id {
+        if full_unit.session_id() != self.config.session_id {
             // NOTE: this implies malicious behavior as the unit's session_id
             // is incompatible with session_id of the message it arrived in.
             debug!(target: "rush-member", "A unit with incorrect session_id! {:?}", full_unit);
@@ -390,9 +386,7 @@ where
     fn move_units_to_consensus(&mut self) {
         let mut units = Vec::new();
         for su in self.store.yield_buffer_units() {
-            let full_unit = su.as_signable();
-            let hash = full_unit.hash();
-            let unit = Unit::new_from_preunit(full_unit.inner.clone(), hash);
+            let unit = su.as_signable().unit();
             units.push(unit);
         }
         if !units.is_empty() {
@@ -453,15 +447,14 @@ where
         let (u_round, u_control_hash, parent_ids) = match self.store.unit_by_hash(&u_hash) {
             Some(su) => {
                 let full_unit = su.as_signable();
+                let parents = &full_unit.control_hash().parents_mask;
+                let parents = (0..parents.len()).into_iter().map(|i| parents[i]);
                 (
                     full_unit.round(),
-                    full_unit.inner.control_hash.hash,
-                    full_unit
-                        .inner
-                        .control_hash
-                        .parents
+                    full_unit.control_hash().hash,
+                    parents
                         .enumerate()
-                        .filter_map(|(i, b)| if *b { Some(i) } else { None })
+                        .filter_map(|(i, b)| if b { Some(i.into()) } else { None })
                         .collect::<Vec<NodeIndex>>(),
                 )
             }
@@ -717,7 +710,7 @@ where
                     .unit_by_hash(h)
                     .expect("Ordered units must be in store")
                     .as_signable()
-                    .data
+                    .data()
             })
             .collect::<OrderedBatch<D>>();
         if let Err(e) = self.data_io.send_ordered_batch(batch) {

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -78,7 +78,7 @@ impl<H: Hasher> TerminalUnit<H> {
     pub(crate) fn verify_control_hash(&self) -> bool {
         // this will be called only after all parents have been reconstructed
 
-        self.unit.control_hash().hash == ControlHash::<H>::combine_hashes(&self.parents)
+        self.unit.control_hash().combined_hash == ControlHash::<H>::combine_hashes(&self.parents)
     }
 }
 

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -6,7 +6,7 @@ use crate::{
     extender::ExtenderUnit,
     member::{NotificationIn, NotificationOut},
     nodes::{NodeCount, NodeIndex, NodeMap},
-    units::{ControlHash, Unit},
+    units::{ControlHash, Unit, UnitCoord},
     Hasher, Receiver, RequestAuxData, Round, Sender,
 };
 use log::{debug, error};
@@ -43,7 +43,7 @@ pub struct TerminalUnit<H: Hasher> {
 
 impl<H: Hasher> From<TerminalUnit<H>> for ExtenderUnit<H> {
     fn from(u: TerminalUnit<H>) -> ExtenderUnit<H> {
-        ExtenderUnit::new(u.unit.creator, u.unit.round(), u.unit.hash, u.parents)
+        ExtenderUnit::new(u.unit.creator(), u.unit.round(), u.unit.hash(), u.parents)
     }
 }
 
@@ -56,8 +56,8 @@ impl<H: Hasher> From<TerminalUnit<H>> for Unit<H> {
 impl<H: Hasher> TerminalUnit<H> {
     // creates a unit from a Control Hash Unit, that has no parents reconstructed yet
     pub(crate) fn blank_from_unit(unit: &Unit<H>) -> Self {
-        let n_members = unit.control_hash.n_members();
-        let n_parents = unit.control_hash.n_parents();
+        let n_members = unit.control_hash().n_members();
+        let n_parents = unit.control_hash().n_parents();
         TerminalUnit {
             unit: unit.clone(),
             parents: NodeMap::new_with_len(n_members),
@@ -72,13 +72,13 @@ impl<H: Hasher> TerminalUnit<H> {
     }
 
     pub(crate) fn _hash(&self) -> H::Hash {
-        self.unit.hash
+        self.unit.hash()
     }
 
     pub(crate) fn verify_control_hash(&self) -> bool {
         // this will be called only after all parents have been reconstructed
 
-        self.unit.control_hash.hash == ControlHash::<H>::combine_hashes(&self.parents)
+        self.unit.control_hash().hash == ControlHash::<H>::combine_hashes(&self.parents)
     }
 }
 
@@ -206,8 +206,8 @@ impl<H: Hasher> Terminal<H> {
     }
 
     fn update_on_store_add(&mut self, u: Unit<H>) {
-        let u_hash = u.hash;
-        let (u_round, pid) = (u.round(), u.creator);
+        let u_hash = u.hash();
+        let (u_round, pid) = (u.round(), u.creator());
         // If u is a fork, then the below line will overwrite the previous unit at this coord, but this is intended
         // and does not break correctness.
         self.unit_by_coord.insert((u_round, pid), u_hash);
@@ -222,21 +222,20 @@ impl<H: Hasher> Terminal<H> {
                 .push_back(TerminalEvent::ParentsReconstructed(u_hash));
         } else {
             let mut coords_to_request = Vec::new();
-            for (i, b) in u.control_hash.parents.enumerate() {
-                if *b {
-                    let coord = (u_round - 1, i);
-                    let maybe_hash = self.unit_by_coord.get(&coord).cloned();
-                    match maybe_hash {
-                        Some(v_hash) => self.reconstruct_parent(&u_hash, i, &v_hash),
-                        None => {
-                            self.add_coord_trigger(u_round - 1, i, u_hash);
-                            coords_to_request.push((u.round() - 1, i).into());
-                        }
+            for i in u.control_hash().parents() {
+                let coord = (u_round - 1, i);
+                let maybe_hash = self.unit_by_coord.get(&coord).cloned();
+                match maybe_hash {
+                    Some(v_hash) => self.reconstruct_parent(&u_hash, i, &v_hash),
+                    None => {
+                        self.add_coord_trigger(u_round - 1, i, u_hash);
+                        let coord = UnitCoord::new(u.round() - 1, i);
+                        coords_to_request.push(coord);
                     }
                 }
             }
             if !coords_to_request.is_empty() {
-                let aux_data = RequestAuxData::new(u.creator);
+                let aux_data = RequestAuxData::new(u.creator());
                 debug!(target: "rush-terminal", "{} Missing coords {:?} aux {:?}", self.node_id, coords_to_request, aux_data);
                 let send_result = self
                     .ntfct_tx
@@ -279,19 +278,15 @@ impl<H: Hasher> Terminal<H> {
             .unit_store
             .get_mut(&u_hash)
             .expect("unit with wrong control hash must be in store");
-        let mut counter = 0;
-        for (i, b) in u.unit.control_hash.parents.enumerate() {
-            if *b {
-                u.parents[i] = Some(p_hashes[counter]);
-                counter += 1;
-            }
+        for (counter, i) in u.unit.control_hash().parents().enumerate() {
+            u.parents[i] = Some(p_hashes[counter]);
         }
         u.n_miss_par_decoded = NodeCount(0);
         self.inspect_parents_in_dag(&u_hash);
     }
 
     fn add_to_store(&mut self, u: Unit<H>) {
-        debug!(target: "rush-terminal", "{} Adding to store {:?} round {:?} index {:?}", self.node_id, u.hash(), u.round(), u.creator);
+        debug!(target: "rush-terminal", "{} Adding to store {:?} round {:?} index {:?}", self.node_id, u.hash(), u.round(), u.creator());
         if let Entry::Vacant(entry) = self.unit_store.entry(u.hash()) {
             entry.insert(TerminalUnit::<H>::blank_from_unit(&u));
             self.update_on_store_add(u);
@@ -353,7 +348,7 @@ impl<H: Hasher> Terminal<H> {
                 TerminalEvent::ParentsInDag(u_hash) => {
                     let u = self.unit_store.get_mut(&u_hash).unwrap();
                     u.status = UnitStatus::InDag;
-                    debug!(target: "rush-terminal", "{} Adding to Dag {:?} round {:?} index {}.", self.node_id, u_hash, u.unit.round(), u.unit.creator);
+                    debug!(target: "rush-terminal", "{} Adding to Dag {:?} round {:?} index {}.", self.node_id, u_hash, u.unit.round(), u.unit.creator());
                     self.update_on_dag_add(&u_hash);
                 }
             }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -92,8 +92,9 @@ pub mod mock {
             match ntfct {
                 NotificationOut::CreatedPreUnit(pu) => {
                     let hash = pu.using_encoded(Hasher64::hash);
-                    let u = Unit::new_from_preunit(pu, hash);
-                    self.units_by_coord.insert(u.clone().into(), u.clone());
+                    let u = Unit::new(pu, hash);
+                    let coord = UnitCoord::new(u.round(), u.creator());
+                    self.units_by_coord.insert(coord, u.clone());
                     self.send_to_all(NotificationIn::NewUnits(vec![u]));
                 }
                 NotificationOut::MissingUnits(coords, _aux_data) => {

--- a/src/units.rs
+++ b/src/units.rs
@@ -126,13 +126,21 @@ impl<H: Hasher> PreUnit<H> {
 }
 
 ///
-#[derive(Debug, Default, Clone, PartialEq, Encode, Decode)]
+#[derive(Debug, Default, Clone, Encode, Decode)]
 pub(crate) struct FullUnit<H: Hasher, D: Data> {
     pre_unit: PreUnit<H>,
     data: D,
     session_id: SessionId,
     #[codec(skip)]
     hash: RefCell<Option<H::Hash>>,
+}
+
+impl<H: Hasher, D: Data> PartialEq for FullUnit<H, D> {
+    fn eq(&self, other: &Self) -> bool {
+        self.pre_unit == other.pre_unit
+            && self.data == other.data
+            && self.session_id == other.session_id
+    }
 }
 
 impl<H: Hasher, D: Data> FullUnit<H, D> {
@@ -258,6 +266,7 @@ mod tests {
         let ch = ControlHash::<Hasher64>::new(&vec![].into());
         let pre_unit = PreUnit::new(NodeIndex(5), 6, ch);
         let full_unit = FullUnit::new(pre_unit, 7, 8);
+        full_unit.hash();
         let encoded = full_unit.encode();
         let decoded = FullUnit::decode(&mut encoded.as_slice()).expect("should decode correctly");
         assert_eq!(decoded, full_unit);

--- a/src/units.rs
+++ b/src/units.rs
@@ -245,6 +245,15 @@ mod tests {
     }
 
     #[test]
+    fn test_control_hash_codec() {
+        let ch = ControlHash::<Hasher64>::new(&vec![Some([0; 8]), None, Some([1; 8])].into());
+        let encoded = ch.encode();
+        let decoded =
+            ControlHash::decode(&mut encoded.as_slice()).expect("should decode correctly");
+        assert_eq!(decoded, ch);
+    }
+
+    #[test]
     fn test_full_unit_codec() {
         let ch = ControlHash::<Hasher64>::new(&vec![].into());
         let pre_unit = PreUnit::new(NodeIndex(5), 6, ch);

--- a/src/units.rs
+++ b/src/units.rs
@@ -1,116 +1,109 @@
 use crate::{
-    member::NotificationOut,
     signed::{Signable, Signed, UncheckedSigned},
     Data, Hasher, Index, KeyBox, NodeCount, NodeIndex, NodeMap, Round, SessionId,
 };
-use codec::{Decode, Encode};
+use codec::{Decode, Encode, Error, Input, Output};
 use log::error;
 use std::{collections::HashMap, hash::Hash as StdHash};
 
-// TODO: need to make sure we never accept units of round > MAX_ROUND
-pub(crate) const MAX_ROUND: usize = 5000;
-
-#[derive(Debug, Clone, Encode, Decode)]
-pub(crate) struct FullUnit<H: Hasher, D: Data> {
-    pub(crate) inner: PreUnit<H>,
-    pub(crate) data: D,
-    pub(crate) session_id: SessionId,
-}
-
-impl<H: Hasher, D: Data> FullUnit<H, D> {
-    pub(crate) fn creator(&self) -> NodeIndex {
-        self.inner.creator
-    }
-    pub(crate) fn round(&self) -> Round {
-        self.inner.round()
-    }
-
-    pub(crate) fn coord(&self) -> UnitCoord {
-        (self.round(), self.creator()).into()
-    }
-
-    pub(crate) fn hash(&self) -> H::Hash {
-        H::hash(&self.encode())
-    }
-}
-
-impl<H: Hasher, D: Data> Signable for FullUnit<H, D> {
-    type Hash = H::Hash;
-    fn hash(&self) -> H::Hash {
-        self.using_encoded(H::hash)
-    }
-}
-
-impl<H: Hasher, D: Data> Index for FullUnit<H, D> {
-    fn index(&self) -> NodeIndex {
-        self.inner.creator
-    }
-}
-
-pub(crate) type UncheckedSignedUnit<H, D, S> = UncheckedSigned<FullUnit<H, D>, S>;
-
-pub(crate) type SignedUnit<'a, H, D, KB> = Signed<'a, FullUnit<H, D>, KB>;
-
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Encode, Decode, StdHash)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Encode, Decode, StdHash)]
 pub(crate) struct UnitCoord {
-    pub(crate) creator: NodeIndex,
-    pub(crate) round: u64,
+    round: u16,
+    creator: NodeIndex,
 }
 
-impl<H: Hasher> From<Unit<H>> for UnitCoord {
-    fn from(unit: Unit<H>) -> Self {
-        UnitCoord {
-            creator: unit.creator(),
-            round: unit.round() as u64,
+impl UnitCoord {
+    pub fn new(round: Round, creator: NodeIndex) -> Self {
+        Self {
+            creator,
+            round: round as u16,
         }
     }
-}
 
-impl<H: Hasher> From<&Unit<H>> for UnitCoord {
-    fn from(unit: &Unit<H>) -> Self {
-        UnitCoord {
-            creator: unit.creator(),
-            round: unit.round() as u64,
-        }
-    }
-}
-
-impl From<(usize, NodeIndex)> for UnitCoord {
-    fn from(coord: (usize, NodeIndex)) -> Self {
-        UnitCoord {
-            creator: coord.1,
-            round: coord.0 as u64,
-        }
-    }
-}
-
-type UnitRound = u64;
-
-#[derive(Clone, Debug, PartialEq, Encode, Decode)]
-pub(crate) struct PreUnit<H: Hasher> {
-    pub(crate) creator: NodeIndex,
-    pub(crate) round: UnitRound,
-    pub(crate) control_hash: ControlHash<H>,
-}
-
-impl<H: Hasher> PreUnit<H> {
-    pub(crate) fn creator(&self) -> NodeIndex {
+    pub fn creator(&self) -> NodeIndex {
         self.creator
     }
 
-    pub(crate) fn round(&self) -> Round {
+    pub fn round(&self) -> Round {
         self.round as Round
     }
+}
 
-    pub(crate) fn new_from_parents(
-        creator: NodeIndex,
-        round: Round,
-        parents: NodeMap<Option<H::Hash>>,
-    ) -> Self {
-        let control_hash = ControlHash::new(&parents);
+/// Combined hashes of the parents of a unit together with the set of indices of creators of the
+/// parents
+#[derive(Clone, Debug, Default, PartialEq)]
+pub(crate) struct ControlHash<H: Hasher> {
+    pub(crate) parents_mask: bit_vec::BitVec<u32>,
+    pub(crate) hash: H::Hash,
+}
+
+impl<H: Hasher> ControlHash<H> {
+    pub(crate) fn new(parent_map: &NodeMap<Option<H::Hash>>) -> Self {
+        let hash = Self::combine_hashes(&parent_map);
+        let parents = parent_map.iter().map(Option::is_some).collect();
+
+        ControlHash {
+            parents_mask: parents,
+            hash,
+        }
+    }
+
+    pub(crate) fn combine_hashes(parent_map: &NodeMap<Option<H::Hash>>) -> H::Hash {
+        parent_map.using_encoded(H::hash)
+    }
+
+    pub(crate) fn parents(&self) -> impl Iterator<Item = NodeIndex> + '_ {
+        self.parents_mask
+            .iter()
+            .enumerate()
+            .filter(|(_, b)| *b)
+            .map(|(i, _)| i.into())
+    }
+
+    pub(crate) fn n_parents(&self) -> NodeCount {
+        NodeCount(self.parents().count())
+    }
+
+    pub(crate) fn n_members(&self) -> NodeCount {
+        NodeCount(self.parents_mask.len())
+    }
+}
+
+impl<H: Hasher> Encode for ControlHash<H> {
+    fn encode_to<T: Output + ?Sized>(&self, dest: &mut T) {
+        (self.parents_mask.len() as u32).encode_to(dest);
+        self.parents_mask.to_bytes().encode_to(dest);
+        self.hash.encode_to(dest);
+    }
+}
+
+impl<H: Hasher> Decode for ControlHash<H> {
+    fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
+        let len = u32::decode(input)?;
+        let bytes = Vec::decode(input)?;
+        let mut parents = bit_vec::BitVec::from_bytes(&bytes);
+        parents.truncate(len as usize);
+        let hash = H::Hash::decode(input)?;
+        Ok(ControlHash {
+            parents_mask: parents,
+            hash,
+        })
+    }
+}
+
+/// The simplest type representing a unit, consisting
+#[derive(Clone, Debug, Default, PartialEq, Encode, Decode)]
+pub(crate) struct PreUnit<H: Hasher> {
+    coord: UnitCoord,
+    // round is stored as `u16` not `Round = usize` for efficiency. Also, `usize` does not implement
+    // Encode + Decode.
+    control_hash: ControlHash<H>,
+}
+
+impl<H: Hasher> PreUnit<H> {
+    pub(crate) fn new(creator: NodeIndex, round: Round, control_hash: ControlHash<H>) -> Self {
         PreUnit {
-            creator,
-            round: round as u64,
+            coord: UnitCoord::new(round, creator),
             control_hash,
         }
     }
@@ -122,231 +115,128 @@ impl<H: Hasher> PreUnit<H> {
     pub(crate) fn n_members(&self) -> NodeCount {
         self.control_hash.n_members()
     }
-}
 
-impl<H: Hasher> From<PreUnit<H>> for NotificationOut<H> {
-    fn from(pu: PreUnit<H>) -> Self {
-        NotificationOut::CreatedPreUnit(pu)
+    pub(crate) fn creator(&self) -> NodeIndex {
+        self.coord.creator()
+    }
+    pub(crate) fn round(&self) -> Round {
+        self.coord.round()
+    }
+    pub(crate) fn control_hash(&self) -> &ControlHash<H> {
+        &self.control_hash
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Encode, Decode)]
-pub(crate) struct Unit<H: Hasher> {
-    pub(crate) creator: NodeIndex,
-    round: UnitRound,
-    pub(crate) hash: H::Hash,
-    pub(crate) control_hash: ControlHash<H>,
+///
+#[derive(Debug, Default, Clone, Encode, Decode)]
+pub(crate) struct FullUnit<H: Hasher, D: Data> {
+    pre_unit: PreUnit<H>,
+    data: D,
+    session_id: SessionId,
+    #[codec(skip)]
+    hash: H::Hash,
 }
 
-impl<H: Hasher> Unit<H> {
+impl<H: Hasher, D: Data> FullUnit<H, D> {
+    pub(crate) fn new(pre_unit: PreUnit<H>, data: D, session_id: SessionId) -> Self {
+        let mut full_unit = FullUnit {
+            pre_unit,
+            data,
+            session_id,
+            hash: Default::default(),
+        };
+        full_unit.hash = full_unit.using_encoded(H::hash);
+        full_unit
+    }
+    pub(crate) fn as_pre_unit(&self) -> &PreUnit<H> {
+        &self.pre_unit
+    }
+    pub(crate) fn creator(&self) -> NodeIndex {
+        self.pre_unit.creator()
+    }
+    pub(crate) fn round(&self) -> Round {
+        self.pre_unit.round()
+    }
+    pub(crate) fn control_hash(&self) -> &ControlHash<H> {
+        &self.pre_unit.control_hash()
+    }
+    pub(crate) fn coord(&self) -> UnitCoord {
+        self.pre_unit.coord
+    }
+    pub(crate) fn data(&self) -> D {
+        self.data
+    }
+    pub(crate) fn session_id(&self) -> SessionId {
+        self.session_id
+    }
     pub(crate) fn hash(&self) -> H::Hash {
         self.hash
     }
+    pub(crate) fn unit(&self) -> Unit<H> {
+        Unit::new(self.pre_unit.clone(), self.hash)
+    }
+}
 
+impl<H: Hasher, D: Data> Signable for FullUnit<H, D> {
+    type Hash = H::Hash;
+    fn hash(&self) -> H::Hash {
+        self.hash()
+    }
+}
+
+impl<H: Hasher, D: Data> Index for FullUnit<H, D> {
+    fn index(&self) -> NodeIndex {
+        self.creator()
+    }
+}
+
+pub(crate) type UncheckedSignedUnit<H, D, S> = UncheckedSigned<FullUnit<H, D>, S>;
+
+pub(crate) type SignedUnit<'a, H, D, KB> = Signed<'a, FullUnit<H, D>, KB>;
+
+#[derive(Clone, Debug, Default, PartialEq, Encode, Decode)]
+pub(crate) struct Unit<H: Hasher> {
+    pre_unit: PreUnit<H>,
+    hash: H::Hash,
+}
+
+impl<H: Hasher> Unit<H> {
+    pub(crate) fn new(pre_unit: PreUnit<H>, hash: H::Hash) -> Self {
+        Unit { pre_unit, hash }
+    }
     pub(crate) fn creator(&self) -> NodeIndex {
-        self.creator
+        self.pre_unit.creator()
     }
     pub(crate) fn round(&self) -> Round {
-        self.round as Round
+        self.pre_unit.round()
     }
-
-    pub(crate) fn new_from_preunit(pu: PreUnit<H>, hash: H::Hash) -> Self {
-        Unit {
-            creator: pu.creator,
-            round: pu.round,
-            hash,
-            control_hash: pu.control_hash,
-        }
+    pub(crate) fn control_hash(&self) -> &ControlHash<H> {
+        self.pre_unit.control_hash()
     }
-}
-#[derive(Clone, Debug, Default, PartialEq, Encode, Decode)]
-pub(crate) struct ControlHash<H: Hasher> {
-    // TODO we need to optimize it for it to take O(N) bits of memory not O(N) words.
-    pub(crate) parents: NodeMap<bool>,
-    pub(crate) hash: H::Hash,
-}
-
-impl<H: Hasher> ControlHash<H> {
-    fn new(parent_map: &NodeMap<Option<H::Hash>>) -> Self {
-        let hash = Self::combine_hashes(&parent_map);
-        let parents = parent_map.iter().map(|h| h.is_some()).collect();
-
-        ControlHash { parents, hash }
-    }
-
-    pub(crate) fn combine_hashes(parent_map: &NodeMap<Option<H::Hash>>) -> H::Hash {
-        parent_map.using_encoded(H::hash)
-    }
-
-    pub(crate) fn n_parents(&self) -> NodeCount {
-        NodeCount(self.parents.iter().filter(|&b| *b).count())
-    }
-
-    pub(crate) fn n_members(&self) -> NodeCount {
-        NodeCount(self.parents.len())
+    pub(crate) fn hash(&self) -> H::Hash {
+        self.hash
     }
 }
 
-pub(crate) struct UnitStore<'a, H: Hasher, D: Data, KB: KeyBox> {
-    by_coord: HashMap<UnitCoord, SignedUnit<'a, H, D, KB>>,
-    by_hash: HashMap<H::Hash, SignedUnit<'a, H, D, KB>>,
-    parents: HashMap<H::Hash, Vec<H::Hash>>,
-    //this is the smallest r, such that round r-1 is saturated, i.e., it has at least threshold (~(2/3)N) units
-    round_in_progress: usize,
-    threshold: NodeCount,
-    //the number of unique nodes that we hold units for a given round
-    n_units_per_round: Vec<NodeCount>,
-    is_forker: NodeMap<bool>,
-    legit_buffer: Vec<SignedUnit<'a, H, D, KB>>,
-}
+mod store;
+pub(crate) use store::*;
 
-impl<'a, H: Hasher, D: Data, KB: KeyBox> UnitStore<'a, H, D, KB> {
-    pub(crate) fn new(n_nodes: NodeCount, threshold: NodeCount) -> Self {
-        UnitStore {
-            by_coord: HashMap::new(),
-            by_hash: HashMap::new(),
-            parents: HashMap::new(),
-            round_in_progress: 0,
-            threshold,
-            n_units_per_round: vec![NodeCount(0); MAX_ROUND + 1],
-            // is_forker is initialized with default values for bool, i.e., false
-            is_forker: NodeMap::new_with_len(n_nodes),
-            legit_buffer: Vec::new(),
-        }
-    }
+#[cfg(test)]
+mod tests {
+    use crate::{
+        nodes::NodeIndex,
+        testing::mock::Hasher64,
+        units::{ControlHash, FullUnit, PreUnit},
+        Hasher,
+    };
+    use codec::Encode;
 
-    pub(crate) fn unit_by_coord(&self, coord: UnitCoord) -> Option<&SignedUnit<'a, H, D, KB>> {
-        self.by_coord.get(&coord)
-    }
-
-    pub(crate) fn unit_by_hash(&self, hash: &H::Hash) -> Option<&SignedUnit<'a, H, D, KB>> {
-        self.by_hash.get(hash)
-    }
-
-    pub(crate) fn contains_hash(&self, hash: &H::Hash) -> bool {
-        self.by_hash.contains_key(hash)
-    }
-
-    pub(crate) fn contains_coord(&self, coord: &UnitCoord) -> bool {
-        self.by_coord.contains_key(coord)
-    }
-
-    // Outputs new legit units that are supposed to be sent to Consensus and emties the buffer.
-    pub(crate) fn yield_buffer_units(&mut self) -> Vec<SignedUnit<'a, H, D, KB>> {
-        std::mem::take(&mut self.legit_buffer)
-    }
-
-    fn update_round_in_progress(&mut self, candidate_round: usize) {
-        if candidate_round >= self.round_in_progress
-            && self.n_units_per_round[candidate_round] >= self.threshold
-        {
-            let old_round = self.round_in_progress;
-            self.round_in_progress = candidate_round + 1;
-            for round in (old_round + 1)..(self.round_in_progress + 1) {
-                for (id, forker) in self.is_forker.enumerate() {
-                    if !*forker {
-                        let coord = (round, id).into();
-                        if let Some(su) = self.unit_by_coord(coord).cloned() {
-                            self.legit_buffer.push(su);
-                        }
-                    }
-                }
-            }
-        }
-    }
-    // Outputs None if this is not a newly-discovered fork or Some(sv) where (su, sv) form a fork
-    pub(crate) fn is_new_fork(
-        &self,
-        su: &SignedUnit<'a, H, D, KB>,
-    ) -> Option<SignedUnit<'a, H, D, KB>> {
-        // TODO: optimize so that unit's hash is computed once only, after it is received
-        let hash = su.as_signable().hash();
-        if self.contains_hash(&hash) {
-            return None;
-        }
-        let coord = su.as_signable().coord();
-        self.unit_by_coord(coord).cloned()
-    }
-
-    pub(crate) fn get_round_in_progress(&self) -> usize {
-        self.round_in_progress
-    }
-
-    pub(crate) fn is_forker(&self, node_id: NodeIndex) -> bool {
-        self.is_forker[node_id]
-    }
-
-    // Marks a node as a forker and outputs units in store of round <= round_in_progress created by this node.
-    // The returned vector is sorted w.r.t. increasing rounds. Units of higher round created by this node are removed from store.
-    pub(crate) fn mark_forker(&mut self, forker: NodeIndex) -> Vec<SignedUnit<'a, H, D, KB>> {
-        if self.is_forker[forker] {
-            error!(target: "env", "Trying to mark the node {:?} as forker for the second time.", forker);
-        }
-        self.is_forker[forker] = true;
-        let forkers_units = (0..=self.round_in_progress)
-            .filter_map(|r| self.unit_by_coord((r, forker).into()).cloned())
-            .collect();
-
-        for round in self.round_in_progress + 1..=MAX_ROUND {
-            let coord = (round, forker).into();
-            if let Some(su) = self.unit_by_coord(coord).cloned() {
-                // We get rid of this unit. This is safe because it has not been sent to Consensus yet.
-                // The reason we do that, is to be in a "clean" situation where we alert all forker's
-                // units in the store and the only way this forker's unit is sent to Consensus is when
-                // it arrives in an alert for the *first* time.
-                // If we didn't do that, then there would be some awkward issues with duplicates.
-                self.by_coord.remove(&coord);
-                let hash = su.as_signable().hash();
-                self.by_hash.remove(&hash);
-                self.parents.remove(&hash);
-                // Now we are in a state as if the unit never arrived.
-            }
-        }
-        forkers_units
-    }
-
-    pub(crate) fn add_unit(&mut self, su: SignedUnit<'a, H, D, KB>, alert: bool) {
-        // TODO: optimize so that unit's hash is computed once only, after it is received
-        let hash = su.as_signable().hash();
-        let round = su.as_signable().round();
-        let creator = su.as_signable().creator();
-        if alert {
-            assert!(
-                self.is_forker[creator],
-                "The forker must be marked before adding alerted units."
-            );
-        }
-        if self.contains_hash(&hash) {
-            // Ignoring a duplicate.
-            return;
-        }
-        self.by_hash.insert(hash, su.clone());
-        let coord = su.as_signable().coord();
-        // We do not store multiple forks of a unit by coord, as there is never a need to
-        // fetch all units corresponding to a particular coord.
-        if self.by_coord.insert(coord, su.clone()).is_none() {
-            // This means that this unit is not a fork (even though the creator might be a forker)
-            self.n_units_per_round[round] += NodeCount(1);
-        }
-        // NOTE: a minor inefficiency is that we send alerted units of high rounds that are possibly
-        // way beyond round_in_progress right away to Consensus. This could be perhaps corrected so that
-        // we wait until the round is in progress, but this does not seem to help vs actual attacks and in
-        // "accidental" forks the rounds will never be much higher than round_in_progress.
-        if alert || (round <= self.round_in_progress && !self.is_forker[creator]) {
-            self.legit_buffer.push(su);
-        }
-        self.update_round_in_progress(round);
-    }
-
-    pub(crate) fn add_parents(&mut self, hash: H::Hash, parents: Vec<H::Hash>) {
-        self.parents.insert(hash, parents);
-    }
-
-    pub(crate) fn get_parents(&mut self, hash: H::Hash) -> Option<&Vec<H::Hash>> {
-        self.parents.get(&hash)
-    }
-
-    pub(crate) fn limit_per_node(&self) -> Round {
-        MAX_ROUND
+    #[test]
+    fn test_full_unit_hash() {
+        let ch = ControlHash::<Hasher64>::new(&vec![].into());
+        let pre_unit = PreUnit::new(NodeIndex(5), 6, ch);
+        let full_unit = FullUnit::new(pre_unit, 7, 8);
+        let hash = full_unit.using_encoded(Hasher64::hash);
+        assert_eq!(full_unit.hash, hash);
     }
 }

--- a/src/units.rs
+++ b/src/units.rs
@@ -166,7 +166,8 @@ impl<H: Hasher, D: Data> FullUnit<H, D> {
         self.session_id
     }
     pub(crate) fn hash(&self) -> H::Hash {
-        match *self.hash.borrow() {
+        let hash = *self.hash.borrow();
+        match hash {
             Some(hash) => hash,
             None => {
                 let hash = self.using_encoded(H::hash);

--- a/src/units/store.rs
+++ b/src/units/store.rs
@@ -1,0 +1,166 @@
+use super::*;
+
+// TODO: need to make sure we never accept units of round > MAX_ROUND
+pub(crate) const MAX_ROUND: usize = 5000;
+
+pub(crate) struct UnitStore<'a, H: Hasher, D: Data, KB: KeyBox> {
+    by_coord: HashMap<UnitCoord, SignedUnit<'a, H, D, KB>>,
+    by_hash: HashMap<H::Hash, SignedUnit<'a, H, D, KB>>,
+    parents: HashMap<H::Hash, Vec<H::Hash>>,
+    //this is the smallest r, such that round r-1 is saturated, i.e., it has at least threshold (~(2/3)N) units
+    round_in_progress: usize,
+    threshold: NodeCount,
+    //the number of unique nodes that we hold units for a given round
+    n_units_per_round: Vec<NodeCount>,
+    is_forker: NodeMap<bool>,
+    legit_buffer: Vec<SignedUnit<'a, H, D, KB>>,
+}
+
+impl<'a, H: Hasher, D: Data, KB: KeyBox> UnitStore<'a, H, D, KB> {
+    pub(crate) fn new(n_nodes: NodeCount, threshold: NodeCount) -> Self {
+        UnitStore {
+            by_coord: HashMap::new(),
+            by_hash: HashMap::new(),
+            parents: HashMap::new(),
+            round_in_progress: 0,
+            threshold,
+            n_units_per_round: vec![NodeCount(0); MAX_ROUND + 1],
+            // is_forker is initialized with default values for bool, i.e., false
+            is_forker: NodeMap::new_with_len(n_nodes),
+            legit_buffer: Vec::new(),
+        }
+    }
+
+    pub(crate) fn unit_by_coord(&self, coord: UnitCoord) -> Option<&SignedUnit<'a, H, D, KB>> {
+        self.by_coord.get(&coord)
+    }
+
+    pub(crate) fn unit_by_hash(&self, hash: &H::Hash) -> Option<&SignedUnit<'a, H, D, KB>> {
+        self.by_hash.get(hash)
+    }
+
+    pub(crate) fn contains_hash(&self, hash: &H::Hash) -> bool {
+        self.by_hash.contains_key(hash)
+    }
+
+    pub(crate) fn contains_coord(&self, coord: &UnitCoord) -> bool {
+        self.by_coord.contains_key(coord)
+    }
+
+    // Outputs new legit units that are supposed to be sent to Consensus and emties the buffer.
+    pub(crate) fn yield_buffer_units(&mut self) -> Vec<SignedUnit<'a, H, D, KB>> {
+        std::mem::take(&mut self.legit_buffer)
+    }
+
+    fn update_round_in_progress(&mut self, candidate_round: usize) {
+        if candidate_round >= self.round_in_progress
+            && self.n_units_per_round[candidate_round] >= self.threshold
+        {
+            let old_round = self.round_in_progress;
+            self.round_in_progress = candidate_round + 1;
+            for round in (old_round + 1)..(self.round_in_progress + 1) {
+                for (id, forker) in self.is_forker.enumerate() {
+                    if !*forker {
+                        let coord = UnitCoord::new(round, id);
+                        if let Some(su) = self.unit_by_coord(coord).cloned() {
+                            self.legit_buffer.push(su);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    // Outputs None if this is not a newly-discovered fork or Some(sv) where (su, sv) form a fork
+    pub(crate) fn is_new_fork(
+        &self,
+        su: &SignedUnit<'a, H, D, KB>,
+    ) -> Option<SignedUnit<'a, H, D, KB>> {
+        let hash = su.as_signable().hash();
+        if self.contains_hash(&hash) {
+            return None;
+        }
+        let coord = su.as_signable().coord();
+        self.unit_by_coord(coord).cloned()
+    }
+
+    pub(crate) fn get_round_in_progress(&self) -> usize {
+        self.round_in_progress
+    }
+
+    pub(crate) fn is_forker(&self, node_id: NodeIndex) -> bool {
+        self.is_forker[node_id]
+    }
+
+    // Marks a node as a forker and outputs units in store of round <= round_in_progress created by this node.
+    // The returned vector is sorted w.r.t. increasing rounds. Units of higher round created by this node are removed from store.
+    pub(crate) fn mark_forker(&mut self, forker: NodeIndex) -> Vec<SignedUnit<'a, H, D, KB>> {
+        if self.is_forker[forker] {
+            error!(target: "env", "Trying to mark the node {:?} as forker for the second time.", forker);
+        }
+        self.is_forker[forker] = true;
+        let forkers_units = (0..=self.round_in_progress)
+            .filter_map(|r| self.unit_by_coord(UnitCoord::new(r, forker)).cloned())
+            .collect();
+
+        for round in self.round_in_progress + 1..=MAX_ROUND {
+            let coord = UnitCoord::new(round, forker);
+            if let Some(su) = self.unit_by_coord(coord).cloned() {
+                // We get rid of this unit. This is safe because it has not been sent to Consensus yet.
+                // The reason we do that, is to be in a "clean" situation where we alert all forker's
+                // units in the store and the only way this forker's unit is sent to Consensus is when
+                // it arrives in an alert for the *first* time.
+                // If we didn't do that, then there would be some awkward issues with duplicates.
+                self.by_coord.remove(&coord);
+                let hash = su.as_signable().hash();
+                self.by_hash.remove(&hash);
+                self.parents.remove(&hash);
+                // Now we are in a state as if the unit never arrived.
+            }
+        }
+        forkers_units
+    }
+
+    pub(crate) fn add_unit(&mut self, su: SignedUnit<'a, H, D, KB>, alert: bool) {
+        let hash = su.as_signable().hash();
+        let round = su.as_signable().round();
+        let creator = su.as_signable().creator();
+        if alert {
+            assert!(
+                self.is_forker[creator],
+                "The forker must be marked before adding alerted units."
+            );
+        }
+        if self.contains_hash(&hash) {
+            // Ignoring a duplicate.
+            return;
+        }
+        self.by_hash.insert(hash, su.clone());
+        let coord = su.as_signable().coord();
+        // We do not store multiple forks of a unit by coord, as there is never a need to
+        // fetch all units corresponding to a particular coord.
+        if self.by_coord.insert(coord, su.clone()).is_none() {
+            // This means that this unit is not a fork (even though the creator might be a forker)
+            self.n_units_per_round[round] += NodeCount(1);
+        }
+        // NOTE: a minor inefficiency is that we send alerted units of high rounds that are possibly
+        // way beyond round_in_progress right away to Consensus. This could be perhaps corrected so that
+        // we wait until the round is in progress, but this does not seem to help vs actual attacks and in
+        // "accidental" forks the rounds will never be much higher than round_in_progress.
+        if alert || (round <= self.round_in_progress && !self.is_forker[creator]) {
+            self.legit_buffer.push(su);
+        }
+        self.update_round_in_progress(round);
+    }
+
+    pub(crate) fn add_parents(&mut self, hash: H::Hash, parents: Vec<H::Hash>) {
+        self.parents.insert(hash, parents);
+    }
+
+    pub(crate) fn get_parents(&mut self, hash: H::Hash) -> Option<&Vec<H::Hash>> {
+        self.parents.get(&hash)
+    }
+
+    pub(crate) fn limit_per_node(&self) -> Round {
+        MAX_ROUND
+    }
+}


### PR DESCRIPTION
Refactor of the module `units`. The following changes are introduced:

* the implementation of `UnitStore` is moved to a new separate file `src/units/store.rs`,
* the structs in the module are reordered in a more natural order.

* the coordinates of the unit (`UnitCoord`) now store the round number as `u16` instead of `u64`.
* every struct which had fields `round: Round` and `creator: NodeIndex` has them now replaced with `coord: UnitCoord`
* the type of the set of parents in `ControlHash` is changed from `Vec<bool>` with `bit_vec::BitVec<u32>` which consists of roughly N bits.
* in order to standardize the interface, all fields of the `*Unit` structs are made private and are accesed via getters. For convenience, we also have getters to access fields of fields, so that instead of `full_unit.pre_unit.coord.round` we now can write `full_unit.round()`.
* the hash of a `FullUnit` is calculated once on creation and stored in a field of `FullUnit`. The hash is not included in the encoding of `FullUnit`
* removed "helper" functions, which do not make reading the code any simpler, and are used for example only once.
