### PR TITLE
Byzantine tests

### DIFF
--- a/src/testing/byzantine.rs
+++ b/src/testing/byzantine.rs
@@ -1,0 +1,297 @@
+use codec::{Decode, Encode};
+
+use log::{debug, error};
+
+use futures::{channel::oneshot, FutureExt, StreamExt};
+
+use std::collections::HashMap;
+
+use crate::{
+    nodes::NodeMap,
+    signed::Signed,
+    testing::mock::{
+        configure_network, init_log, node_ix_to_peer, spawn_honest_member, AlertHook, Data,
+        Hasher64, KeyBox, Network, PeerId, Signature, Spawner,
+    },
+    units::{ControlHash, FullUnit, PreUnit, SignedUnit, UnitCoord},
+    Hasher, Network as NetworkT, NetworkCommand, NetworkEvent, NodeCount, NodeIndex, SessionId,
+    SpawnHandle,
+};
+
+type Hash64 = <Hasher64 as Hasher>::Hash;
+
+use crate::member::{ConsensusMessage, ConsensusMessage::*};
+
+struct MaliciousMember<'a> {
+    node_ix: NodeIndex,
+    n_members: NodeCount,
+    threshold: NodeCount,
+    session_id: SessionId,
+    forking_round: usize,
+    round_in_progress: usize,
+    keybox: &'a KeyBox,
+    network: Network,
+    unit_store: HashMap<UnitCoord, SignedUnit<'a, Hasher64, Data, KeyBox>>,
+}
+
+impl<'a> MaliciousMember<'a> {
+    fn new(
+        keybox: &'a KeyBox,
+        network: Network,
+        node_ix: NodeIndex,
+        n_members: NodeCount,
+        session_id: SessionId,
+        forking_round: usize,
+    ) -> Self {
+        let threshold = (n_members * 2) / 3 + NodeCount(1);
+        MaliciousMember {
+            node_ix,
+            n_members,
+            threshold,
+            session_id,
+            forking_round,
+            round_in_progress: 0,
+            keybox,
+            network,
+            unit_store: HashMap::new(),
+        }
+    }
+
+    fn send_network_command(&mut self, command: NetworkCommand) {
+        if let Err(e) = self.network.send(command) {
+            panic!("Failed to send network command {:?}.", e);
+        }
+    }
+
+    fn pick_parents(&self, round: usize) -> Option<NodeMap<Option<Hash64>>> {
+        // Outputs a parent map if there are enough of them to create a new unit.
+        let mut parents = NodeMap::new_with_len(self.n_members);
+        if round == 0 {
+            return Some(parents);
+        }
+        let mut count = 0;
+        let our_prev_coord = UnitCoord::new(round - 1, self.node_ix);
+        if !self.unit_store.contains_key(&our_prev_coord) {
+            return None;
+        }
+        for i in 0..self.n_members.0 {
+            let ix = NodeIndex(i);
+            let coord = UnitCoord::new(round - 1, ix);
+            if let Some(su) = self.unit_store.get(&coord) {
+                let hash: <Hasher64 as Hasher>::Hash = su.as_signable().hash();
+                parents[ix] = Some(hash);
+                count += 1;
+            }
+        }
+        if NodeCount(count) >= self.threshold {
+            Some(parents)
+        } else {
+            None
+        }
+    }
+
+    fn send_legit_unit(&mut self, su: SignedUnit<'a, Hasher64, Data, KeyBox>) {
+        let message = ConsensusMessage::<Hasher64, Data, Signature>::NewUnit(su.into());
+        let command = NetworkCommand::SendToAll(message.encode());
+        self.send_network_command(command);
+    }
+
+    fn send_two_variants(
+        &mut self,
+        su0: SignedUnit<'a, Hasher64, Data, KeyBox>,
+        su1: SignedUnit<'a, Hasher64, Data, KeyBox>,
+    ) {
+        // We send variant k \in {0,1} to each node with index = k (mod 2)
+        // We also send to ourselves, it does not matter much.
+        let message0 = ConsensusMessage::<Hasher64, Data, Signature>::NewUnit(su0.into());
+        let message1 = ConsensusMessage::<Hasher64, Data, Signature>::NewUnit(su1.into());
+        for ix in 0..self.n_members.0 {
+            let node_ix = NodeIndex(ix);
+            let peer_id = node_ix_to_peer(node_ix);
+            let command = if ix % 2 == 0 {
+                NetworkCommand::SendToPeer(message0.encode(), peer_id)
+            } else {
+                NetworkCommand::SendToPeer(message1.encode(), peer_id)
+            };
+            self.send_network_command(command);
+        }
+    }
+
+    fn create_if_possible(&mut self) {
+        if let Some(parents) = self.pick_parents(self.round_in_progress) {
+            debug!(target: "malicious-member", "Creating a legit unit for round {}.", self.round_in_progress);
+            let round = self.round_in_progress;
+            let control_hash = ControlHash::<Hasher64>::new(&parents);
+            let new_preunit = PreUnit::<Hasher64>::new(self.node_ix, round, control_hash);
+            let coord = UnitCoord::new(round, self.node_ix);
+            if round != self.forking_round {
+                let data = Data::new(coord, 0);
+                let full_unit = FullUnit::new(new_preunit, data, self.session_id);
+                let signed_unit = Signed::sign(self.keybox, full_unit);
+                self.on_unit_received(signed_unit.clone());
+                self.send_legit_unit(signed_unit);
+            } else {
+                // FORKING HAPPENS HERE!
+                debug!(target: "malicious-member", "Creating forks for round {}.", self.round_in_progress);
+                let variants: Vec<SignedUnit<Hasher64, Data, KeyBox>> = (0u32..2u32)
+                    .map(|var| {
+                        let data = Data::new(coord, var);
+                        let full_unit = FullUnit::new(new_preunit.clone(), data, self.session_id);
+                        Signed::sign(self.keybox, full_unit)
+                    })
+                    .collect();
+                self.send_two_variants(variants[0].clone(), variants[1].clone());
+            }
+            self.round_in_progress += 1;
+        }
+    }
+
+    fn on_unit_received(&mut self, su: SignedUnit<'a, Hasher64, Data, KeyBox>) {
+        let full_unit = su.as_signable();
+        let coord: UnitCoord = full_unit.coord();
+        // We don't care if we overwrite something as long as we keep at least one version of a unit
+        // at a given coord.
+        self.unit_store.insert(coord, su);
+    }
+
+    fn on_consensus_message(
+        &mut self,
+        message: ConsensusMessage<Hasher64, Data, Signature>,
+        _peer_id: PeerId,
+    ) {
+        // We ignore all messages except those carrying new units.
+        if let NewUnit(unchecked) = message {
+            debug!(target: "malicious-member", "New unit received {:?}.", &unchecked);
+            match unchecked.check(self.keybox) {
+                Ok(su) => self.on_unit_received(su),
+                Err(unchecked) => {
+                    panic!("Wrong signature received {:?}.", &unchecked);
+                }
+            }
+        }
+        // else we stay silent
+    }
+
+    fn handle_event(&mut self, event: NetworkEvent) {
+        match event {
+            NetworkEvent::MessageReceived(message, sender) => {
+                match ConsensusMessage::decode(&mut &message[..]) {
+                    Ok(message) => {
+                        self.on_consensus_message(message, sender);
+                    }
+                    Err(e) => {
+                        panic!("Error decoding message: {}", e);
+                    }
+                }
+            }
+        }
+    }
+
+    pub async fn run_session(mut self, exit: oneshot::Receiver<()>) {
+        let mut exit = exit.into_stream();
+        self.create_if_possible();
+        loop {
+            tokio::select! {
+                event = self.network.next_event() => match event {
+                    Some(event) => {
+                        self.handle_event(event);
+                    },
+                    None => {
+                        error!(target: "malicious-member", "Network message stream closed.");
+                        break;
+                    }
+                },
+                _ = exit.next() => break,
+            }
+            self.create_if_possible();
+        }
+    }
+}
+
+fn spawn_malicious_member(
+    spawner: Spawner,
+    ix: usize,
+    n_members: usize,
+    round_to_fork: usize,
+    network: Network,
+) -> oneshot::Sender<()> {
+    let node_index = NodeIndex(ix);
+    let (exit_tx, exit_rx) = oneshot::channel();
+    let member_task = async move {
+        let keybox = KeyBox::new(node_index);
+        let session_id = 0u64;
+        let lesniak = MaliciousMember::new(
+            &keybox,
+            network,
+            node_index,
+            NodeCount(n_members),
+            session_id,
+            round_to_fork,
+        );
+        lesniak.run_session(exit_rx).await;
+    };
+    spawner.spawn("malicious-member", member_task);
+    exit_tx
+}
+
+async fn honest_members_agree_on_batches_byzantine(
+    n_members: usize,
+    n_honest: usize,
+    n_batches: usize,
+    network_reliability: f64,
+) {
+    init_log();
+    let spawner = Spawner::new();
+    let mut exits = vec![];
+    let mut batch_rxs = Vec::new();
+    let (net_hub, mut networks) = configure_network(n_members, network_reliability);
+
+    let alert_hook = AlertHook::new();
+    net_hub.add_hook(alert_hook.clone());
+
+    spawner.spawn("network-hub", net_hub);
+
+    for (ix, network) in networks.iter_mut().enumerate() {
+        if ix >= n_honest {
+            let exit_tx =
+                spawn_malicious_member(spawner.clone(), ix, n_members, 2, network.take().unwrap());
+            exits.push(exit_tx);
+        } else {
+            let (batch_rx, exit_tx) =
+                spawn_honest_member(spawner.clone(), ix, n_members, network.take().unwrap());
+            batch_rxs.push(batch_rx);
+            exits.push(exit_tx);
+        }
+    }
+
+    let mut batches = vec![];
+    for mut rx in batch_rxs.drain(..) {
+        let mut batches_per_ix = vec![];
+        for _ in 0..n_batches {
+            let batch = rx.next().await.unwrap();
+            batches_per_ix.push(batch);
+        }
+        batches.push(batches_per_ix);
+    }
+
+    for node_ix in 1..n_honest {
+        debug!("batch {} received", node_ix);
+        assert_eq!(batches[0], batches[node_ix]);
+    }
+
+    // each honest node sends alert once for each malicious member (to each one except himself)
+    assert_eq!(
+        alert_hook.count(),
+        (n_members - n_honest) * n_honest * (n_members - 1)
+    );
+}
+
+#[tokio::test(max_threads = 1)]
+async fn small_byzantine_one_forker() {
+    honest_members_agree_on_batches_byzantine(4, 3, 5, 1.0).await;
+}
+
+#[tokio::test(max_threads = 1)]
+async fn small_byzantine_two_forkers() {
+    honest_members_agree_on_batches_byzantine(7, 5, 5, 1.0).await;
+}

--- a/src/testing/crash.rs
+++ b/src/testing/crash.rs
@@ -1,0 +1,58 @@
+use futures::StreamExt;
+
+use crate::{
+    testing::mock::{configure_network, init_log, spawn_honest_member, Spawner},
+    SpawnHandle,
+};
+
+async fn honest_members_agree_on_batches(
+    n_members: usize,
+    n_alive: usize,
+    n_batches: usize,
+    network_reliability: f64,
+) {
+    init_log();
+    let spawner = Spawner::new();
+    let mut exits = vec![];
+    let mut batch_rxs = Vec::new();
+    let (net_hub, mut networks) = configure_network(n_members, network_reliability);
+    spawner.spawn("network-hub", net_hub);
+
+    for (ix, network) in networks.iter_mut().enumerate() {
+        if ix < n_alive {
+            let (batch_rx, exit_tx) =
+                spawn_honest_member(spawner.clone(), ix, n_members, network.take().unwrap());
+            batch_rxs.push(batch_rx);
+            exits.push(exit_tx);
+        }
+    }
+
+    let mut batches = vec![];
+    for mut rx in batch_rxs.drain(..) {
+        let mut batches_per_ix = vec![];
+        for _ in 0..n_batches {
+            let batch = rx.next().await.unwrap();
+            batches_per_ix.push(batch);
+        }
+        batches.push(batches_per_ix);
+    }
+
+    for node_ix in 1..n_alive {
+        assert_eq!(batches[0], batches[node_ix]);
+    }
+}
+
+#[tokio::test(max_threads = 1)]
+async fn small_honest_all_alive() {
+    honest_members_agree_on_batches(4, 4, 10, 1.0).await;
+}
+
+#[tokio::test(max_threads = 1)]
+async fn small_honest_one_crash() {
+    honest_members_agree_on_batches(4, 3, 10, 1.0).await;
+}
+
+#[tokio::test(max_threads = 1)]
+async fn small_honest_one_crash_unreliable_network() {
+    honest_members_agree_on_batches(4, 3, 10, 0.9).await;
+}

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -1,2 +1,6 @@
 #[cfg(test)]
+pub mod byzantine;
+#[cfg(test)]
+pub mod crash;
+#[cfg(test)]
 pub mod mock;


### PR DESCRIPTION
Tests for Member, including tests with a "byzantine Member".
What these tests do is essentially checking if Member works correctly, i.e., that if a set of Members connected via network (mock in this case) achieves their intended goal, i.e., consistently order some pieces of "Data".
There are test scenarios with honest Members only, and ones where there are byzantine Members, who make unit forks.
Currently the slowest test runs quite long (i.e., depending on randomness between 20s - 30s):
1) This is because there are hardcoded delays of the order of "a couple of secs", for replaying requests for parents (when there is wrong control hash detected etc.). One TODO would be to add these delays to Member configuration.
2) Another reason is that requests at the moment are rather inefficient, in the sense that we request from a random node, and only once per couple of seconds. This is to be improved.
3) In case you wonder: why is there randomness in these tests? Why not make it deterministic? There is no way to make it truly deterministic, because of concurrency which causes a few threads to race.