### PR TITLE
Undo adding Default trait for Hasher::Hash

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,17 +67,7 @@ pub trait Index {
 /// A hasher, used for creating identifiers for blocks or units.
 pub trait Hasher: Eq + Clone + Send + Sync + Debug + 'static {
     /// A hash, as an identifier for a block or unit.
-    type Hash: AsRef<[u8]>
-        + Eq
-        + Ord
-        + Copy
-        + Clone
-        + Send
-        + Debug
-        + StdHash
-        + Encode
-        + Decode
-        + Default;
+    type Hash: AsRef<[u8]> + Eq + Ord + Copy + Clone + Send + Debug + StdHash + Encode + Decode;
 
     fn hash(s: &[u8]) -> Self::Hash;
 }

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -28,7 +28,7 @@ impl Default for UnitStatus {
 
 /// A Unit struct used in the Terminal. It stores a copy of a unit and apart from that some
 /// information on its status, i.e., already reconstructed parents etc.
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct TerminalUnit<H: Hasher> {
     unit: Unit<H>,
     // This represents the knowledge of what we think the parents of the unit are. It is initialized as all None

--- a/src/units.rs
+++ b/src/units.rs
@@ -92,7 +92,7 @@ impl<H: Hasher> Decode for ControlHash<H> {
 }
 
 /// The simplest type representing a unit, consisting of coordinates and a control hash
-#[derive(Clone, Debug, Default, PartialEq, Encode, Decode)]
+#[derive(Clone, Debug, PartialEq, Encode, Decode)]
 pub(crate) struct PreUnit<H: Hasher> {
     coord: UnitCoord,
     control_hash: ControlHash<H>,
@@ -126,7 +126,7 @@ impl<H: Hasher> PreUnit<H> {
 }
 
 ///
-#[derive(Debug, Default, Clone, Encode, Decode)]
+#[derive(Debug, Clone, Encode, Decode)]
 pub(crate) struct FullUnit<H: Hasher, D: Data> {
     pre_unit: PreUnit<H>,
     data: D,
@@ -206,7 +206,7 @@ pub(crate) type UncheckedSignedUnit<H, D, S> = UncheckedSigned<FullUnit<H, D>, S
 
 pub(crate) type SignedUnit<'a, H, D, KB> = Signed<'a, FullUnit<H, D>, KB>;
 
-#[derive(Clone, Debug, Default, PartialEq, Encode, Decode)]
+#[derive(Clone, Debug, PartialEq, Encode, Decode)]
 pub(crate) struct Unit<H: Hasher> {
     pre_unit: PreUnit<H>,
     hash: H::Hash,


### PR DESCRIPTION
Adding the `Default` trait for the associated type `Hash` in the `Hasher` trait was unnecessary (and breaks aleph-node). This PR undoes adding this trait