### PR TITLE
Implement BoolNodeMap and multisigning tools

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,8 @@ mod creator;
 mod extender;
 mod member;
 pub mod nodes;
-pub mod signed;
+mod signed;
+pub use signed::*;
 mod terminal;
 mod testing;
 mod units;
@@ -28,12 +29,6 @@ pub trait DataIO<Data> {
     type Error: Debug;
     fn get_data(&self) -> Data;
     fn send_ordered_batch(&mut self, data: OrderedBatch<Data>) -> Result<(), Self::Error>;
-}
-
-pub trait KeyBox: Index {
-    type Signature: Debug + Clone + Encode + Decode;
-    fn sign(&self, msg: &[u8]) -> Self::Signature;
-    fn verify(&self, msg: &[u8], sgn: &Self::Signature, index: NodeIndex) -> bool;
 }
 
 #[async_trait::async_trait]

--- a/src/member.rs
+++ b/src/member.rs
@@ -325,7 +325,7 @@ where
             return false;
         }
         let control_hash = &pre_unit.control_hash();
-        if round > 0 && !control_hash.parents_mask[pre_unit.creator().0] {
+        if round > 0 && !control_hash.parents_mask[pre_unit.creator()] {
             debug!(target: "rush-member", "{} Unit does not have its creator's previous unit as parent.", self.node_ix());
             return false;
         }

--- a/src/signed.rs
+++ b/src/signed.rs
@@ -1,5 +1,46 @@
-use crate::{nodes::NodeIndex, Index, KeyBox};
+use crate::{nodes::NodeIndex, Index};
 use codec::{Decode, Encode};
+use log::debug;
+use std::fmt::Debug;
+
+/// The type used as a signature. The Signature typically does not contain the index of the node who
+/// signed the data.
+pub trait Signature: Debug + Clone + Encode + Decode {}
+
+impl<T: Debug + Clone + Encode + Decode> Signature for T {}
+
+/// Abstraction of the signing data and verifying signatures. Typically, consists of a private key
+/// of the node and the public keys of all nodes.
+pub trait KeyBox: Index {
+    type Signature: Signature;
+    fn sign(&self, msg: &[u8]) -> Self::Signature;
+    fn verify(&self, msg: &[u8], sgn: &Self::Signature, index: NodeIndex) -> bool;
+}
+
+/// A type to which Signatures can be aggregated.
+/// A single Signature can be rised to a Multisignature, and any signature can be added to
+/// multisignature.
+/// After adding sufficiently many signatures, the partial multisignature becomes a "complete"
+/// multisignature.
+/// Whether a multisignature is complete, can be verified with `[MultiKeychain::is_complete]` method.
+/// The signature and the index passed to the `add_signature` method are required to be valid.
+pub trait PartialMultisignature: Debug + Clone + Encode + Decode {
+    type Signature: Signature;
+    fn add_signature(&mut self, signature: &Self::Signature, index: NodeIndex);
+}
+
+/// Extends KeyBox with multisigning functionalities. Allows to verify whether a partial multisignature
+/// is valid (or complete).
+pub trait MultiKeychain: KeyBox {
+    type PartialMultisignature: PartialMultisignature<Signature = Self::Signature>;
+    fn from_signature(
+        &self,
+        signature: &Self::Signature,
+        index: NodeIndex,
+    ) -> Self::PartialMultisignature;
+    fn is_complete(&self, partial: &Self::PartialMultisignature) -> bool;
+    fn verify_partial(&self, msg: &[u8], partial: &Self::PartialMultisignature) -> bool;
+}
 
 pub trait Signable {
     type Hash: AsRef<[u8]>;
@@ -9,8 +50,9 @@ pub trait Signable {
 /// A pair consisting of an instance of the `Signable` trait and an (arbitrary) signature.
 ///
 /// The methods `[UncheckedSigned::check_with_index]` and `[UncheckedSigned::check]` can be used
-/// to upgrade this `struct` to `[CheckedSigned<T, S>]` which ensures that the signature matches the
-/// signed object.
+/// to upgrade this `struct` to `[Signed<'a, T, KB>]` which ensures that the signature matches the
+/// signed object, and the method `[UncheckedSigned::check_partial]` can be used to upgrade to
+/// `[PartiallyMultisigned<'a, T, MK>]`.
 #[derive(Clone, Debug, Decode, Encode)]
 pub struct UncheckedSigned<T: Signable, S> {
     signable: T,
@@ -18,17 +60,17 @@ pub struct UncheckedSigned<T: Signable, S> {
 }
 
 #[derive(Clone, Debug)]
-pub(crate) struct SignatureError<T: Signable, S> {
+pub struct SignatureError<T: Signable, S> {
     unchecked: UncheckedSigned<T, S>,
 }
 
-impl<T: Signable, S> UncheckedSigned<T, S> {
+impl<T: Signable, S: Clone> UncheckedSigned<T, S> {
     /// Verifies whether the signature matches the key with the given index.
     pub(crate) fn check_with_index<KB: KeyBox<Signature = S>>(
         self,
         key_box: &KB,
         index: NodeIndex,
-    ) -> Result<Signed<T, KB>, SignatureError<T, KB::Signature>> {
+    ) -> Result<Signed<T, KB>, SignatureError<T, S>> {
         if !key_box.verify(self.signable.hash().as_ref(), &self.signature, index) {
             return Err(SignatureError { unchecked: self });
         }
@@ -37,9 +79,22 @@ impl<T: Signable, S> UncheckedSigned<T, S> {
             key_box,
         })
     }
+
+    pub fn check_partial<MK: MultiKeychain<PartialMultisignature = S>>(
+        self,
+        keychain: &MK,
+    ) -> Result<PartiallyMultisigned<T, MK>, SignatureError<T, S>> {
+        if !keychain.verify_partial(self.signable.hash().as_ref(), &self.signature) {
+            return Err(SignatureError { unchecked: self });
+        }
+        Ok(PartiallyMultisigned {
+            unchecked: self,
+            keychain,
+        })
+    }
 }
 
-impl<T: Signable + Index, S> UncheckedSigned<T, S> {
+impl<T: Signable + Index, S: Clone> UncheckedSigned<T, S> {
     /// Verifies, whether the signature matches the key with the index of the signed object.
     pub(crate) fn check<KB: KeyBox<Signature = S>>(
         self,
@@ -98,3 +153,58 @@ impl<'a, T: Signable, KB: KeyBox> From<Signed<'a, T, KB>> for UncheckedSigned<T,
         signed.into_unchecked()
     }
 }
+
+#[derive(Debug)]
+pub struct PartiallyMultisigned<'a, T: Signable, MK: MultiKeychain> {
+    unchecked: UncheckedSigned<T, MK::PartialMultisignature>,
+    keychain: &'a MK,
+}
+
+pub struct Multisigned<'a, T: Signable, MK: MultiKeychain> {
+    pub unchecked: UncheckedSigned<T, MK::PartialMultisignature>,
+    pub keychain: &'a MK,
+}
+
+#[derive(Debug)]
+pub struct IncompleteMultisignatureError<'a, T: Signable, MK: MultiKeychain> {
+    pub partial: PartiallyMultisigned<'a, T, MK>,
+}
+
+impl<'a, T: Signable, MK: MultiKeychain> PartiallyMultisigned<'a, T, MK> {
+    pub fn sign(signable: T, keychain: &'a MK) -> Self {
+        let signature = keychain.sign(signable.hash().as_ref());
+        let multisignature = keychain.from_signature(&signature, keychain.index());
+        PartiallyMultisigned {
+            unchecked: UncheckedSigned {
+                signable,
+                signature: multisignature,
+            },
+            keychain,
+        }
+    }
+    pub fn add_signature(&mut self, signed: Signed<'a, T, MK>, index: NodeIndex) {
+        if self.unchecked.signable.hash().as_ref() != signed.as_signable().hash().as_ref() {
+            debug!("Tried to add a signature of a different object");
+            return;
+        }
+        self.unchecked
+            .signature
+            .add_signature(&signed.unchecked.signature, index);
+    }
+
+    fn _try_into_complete(
+        self,
+        keychain: &'a MK,
+    ) -> Result<Multisigned<'a, T, MK>, IncompleteMultisignatureError<'a, T, MK>> {
+        if !keychain.is_complete(&self.unchecked.signature) {
+            return Err(IncompleteMultisignatureError { partial: self });
+        }
+        Ok(Multisigned {
+            unchecked: self.unchecked,
+            keychain: self.keychain,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/signed/tests.rs
+++ b/src/signed/tests.rs
@@ -1,0 +1,138 @@
+use super::*;
+use crate::{
+    nodes::{BoolNodeMap, NodeCount, NodeIndex},
+    KeyBox, MultiKeychain, PartialMultisignature, Signable,
+};
+use codec::{Decode, Encode};
+
+#[derive(Clone, Debug, PartialEq)]
+struct TestMessage {
+    msg: Vec<u8>,
+}
+
+impl Signable for TestMessage {
+    type Hash = Vec<u8>;
+    fn hash(&self) -> Self::Hash {
+        self.msg.clone()
+    }
+}
+
+#[derive(Debug)]
+struct TestMultiKeychain {
+    node_count: NodeCount,
+    index: NodeIndex,
+}
+
+impl Index for TestMultiKeychain {
+    fn index(&self) -> NodeIndex {
+        self.index
+    }
+}
+
+#[derive(Debug, Clone, Encode, Decode)]
+struct TestSignature {
+    msg: Vec<u8>,
+    index: NodeIndex,
+}
+
+impl KeyBox for TestMultiKeychain {
+    type Signature = TestSignature;
+    fn sign(&self, msg: &[u8]) -> Self::Signature {
+        TestSignature {
+            msg: msg.to_vec(),
+            index: self.index,
+        }
+    }
+    fn verify(&self, msg: &[u8], sgn: &Self::Signature, index: NodeIndex) -> bool {
+        sgn.msg == msg && sgn.index == index
+    }
+}
+
+#[test]
+fn test_signatures() {
+    let node_count: NodeCount = 7.into();
+    let keychains: Vec<TestMultiKeychain> = (0_usize..node_count.0)
+        .map(|i| TestMultiKeychain {
+            node_count,
+            index: i.into(),
+        })
+        .collect();
+    for i in 0_usize..7 {
+        for j in 0_usize..7 {
+            let msg = TestMessage {
+                msg: "Hello".as_bytes().to_vec(),
+            };
+            let signed_msg = Signed::sign(&keychains[i], msg.clone());
+            let unchecked_msg = signed_msg.unchecked;
+            let signed_msg = unchecked_msg
+                .check_with_index(&keychains[j], i.into())
+                .expect("Signed message should be valid");
+            assert_eq!(signed_msg.as_signable(), &msg)
+        }
+    }
+}
+
+#[derive(Clone, Debug, Encode, Decode, PartialEq)]
+struct TestPartialMultisignature {
+    msg: Vec<u8>,
+    signers: BoolNodeMap,
+}
+
+impl PartialMultisignature for TestPartialMultisignature {
+    type Signature = TestSignature;
+
+    fn add_signature(&mut self, signature: &Self::Signature, index: NodeIndex) {
+        if self.msg == signature.msg {
+            self.signers.set(index);
+        }
+    }
+}
+
+impl MultiKeychain for TestMultiKeychain {
+    type PartialMultisignature = TestPartialMultisignature;
+
+    fn from_signature(
+        &self,
+        signature: &Self::Signature,
+        index: NodeIndex,
+    ) -> Self::PartialMultisignature {
+        let mut signers = BoolNodeMap::with_capacity(self.node_count);
+        signers.set(index);
+        TestPartialMultisignature {
+            msg: signature.msg.clone(),
+            signers,
+        }
+    }
+
+    fn is_complete(&self, partial: &Self::PartialMultisignature) -> bool {
+        return 3 * partial.signers.true_indices().count() > 2 * self.node_count.0;
+    }
+
+    fn verify_partial(&self, msg: &[u8], partial: &Self::PartialMultisignature) -> bool {
+        msg == partial.msg
+    }
+}
+
+#[test]
+fn test_multisignatures() {
+    let msg = TestMessage {
+        msg: "Hello".as_bytes().to_vec(),
+    };
+    let node_count: NodeCount = 7.into();
+    let keychains: Vec<TestMultiKeychain> = (0_usize..node_count.0)
+        .map(|i| TestMultiKeychain {
+            node_count,
+            index: i.into(),
+        })
+        .collect();
+
+    let mut partial = PartiallyMultisigned::sign(msg.clone(), &keychains[0]);
+    for &i in [1, 2, 3, 4].iter() {
+        assert!(!keychains[i].is_complete(&partial.unchecked.signature));
+        let signed = Signed::sign(&keychains[i], msg.clone());
+        partial.add_signature(signed, i.into());
+    }
+    if partial._try_into_complete(&keychains[5]).is_err() {
+        panic!("5 signatures should form a complete signature");
+    }
+}


### PR DESCRIPTION
`BoolNodeMap` is a struct with the same functionality as `NodeMap<bool>` but with efficient encoding.

`MultiKeychain` is a new trait extending `KeyBox` with multisigning functionality. Also, as an equivalent of `Signed<'a, T, KB>` for multisignatures, two struct are introduced: `PartiallyMultisigned<'a, T, MK>` and
`MultiSigned<'a, T, MK>`.