### PR TITLE
Reliable Multicast Implementation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub mod nodes;
 mod signed;
 pub use signed::*;
 mod config;
+pub mod rmc;
 mod terminal;
 mod testing;
 mod units;

--- a/src/nodes.rs
+++ b/src/nodes.rs
@@ -7,7 +7,7 @@ use std::{
 };
 
 /// The index of a node
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, From)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash, From)]
 pub struct NodeIndex(pub usize);
 
 impl Encode for NodeIndex {
@@ -96,7 +96,7 @@ impl<T> IndexMut<NodeIndex> for NodeMap<T> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct BoolNodeMap(bit_vec::BitVec<u32>);
 
 impl BoolNodeMap {

--- a/src/rmc.rs
+++ b/src/rmc.rs
@@ -1,0 +1,263 @@
+use crate::{
+    nodes::{NodeCount, NodeIndex},
+    signed::{PartiallyMultisigned, Signable, Signed, UncheckedSigned},
+    Indexed, MultiKeychain, Multisigned, PartialMultisignature, Signature,
+};
+use async_trait::async_trait;
+use core::fmt::Debug;
+use futures::{
+    channel::mpsc::{unbounded, UnboundedReceiver, UnboundedSender},
+    FutureExt, StreamExt,
+};
+use log::debug;
+use std::{
+    cmp::Ordering,
+    collections::{BinaryHeap, HashMap},
+    hash::Hash,
+};
+use tokio::time;
+
+/// A message consists of either a signed (indexed) hash, or a multisigned hash.
+#[derive(Clone)]
+pub enum Message<H: Signable, S: Signature, M: PartialMultisignature> {
+    SignedHash(UncheckedSigned<Indexed<H>, S>),
+    MultisignedHash(UncheckedSigned<H, M>),
+}
+
+impl<H: Signable, S: Signature, M: PartialMultisignature> Message<H, S, M> {
+    pub fn hash(&self) -> &H {
+        match self {
+            Message::SignedHash(unchecked) => unchecked.as_signable().as_signable(),
+            Message::MultisignedHash(unchecked) => unchecked.as_signable(),
+        }
+    }
+}
+
+pub enum Task<H: Signable, MK: MultiKeychain> {
+    BroadcastMessage(Message<H, MK::Signature, MK::PartialMultisignature>),
+}
+
+#[async_trait]
+pub trait TaskScheduler<T> {
+    fn add_task(&mut self, task: T);
+    async fn next_task(&mut self) -> Option<T>;
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ScheduledTask<T> {
+    scheduled_time: time::Instant,
+    task: T,
+    delay: time::Duration,
+}
+
+impl<T> ScheduledTask<T> {
+    fn new(scheduled_time: time::Instant, task: T, delay: time::Duration) -> Self {
+        ScheduledTask {
+            scheduled_time,
+            task,
+            delay,
+        }
+    }
+}
+
+impl<T: Ord> Ord for ScheduledTask<T> {
+    fn cmp(&self, other: &Self) -> Ordering {
+        other
+            .scheduled_time
+            .cmp(&self.scheduled_time)
+            .then_with(|| self.task.cmp(&other.task))
+            .then_with(|| self.delay.cmp(&other.delay))
+    }
+}
+
+impl<T: Ord> PartialOrd for ScheduledTask<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+pub struct DoublingDelayScheduler<T> {
+    initial_delay: time::Duration,
+    scheduled_tasks: BinaryHeap<ScheduledTask<T>>,
+    on_new_task_tx: UnboundedSender<T>,
+    on_new_task_rx: UnboundedReceiver<T>,
+}
+
+impl<T: Ord> DoublingDelayScheduler<T> {
+    pub fn new(initial_delay: time::Duration) -> Self {
+        let (on_new_task_tx, on_new_task_rx) = unbounded();
+        DoublingDelayScheduler {
+            initial_delay,
+            scheduled_tasks: BinaryHeap::new(),
+            on_new_task_tx,
+            on_new_task_rx,
+        }
+    }
+}
+
+#[async_trait]
+impl<T: Ord + Send + Clone> TaskScheduler<T> for DoublingDelayScheduler<T> {
+    fn add_task(&mut self, task: T) {
+        self.on_new_task_tx
+            .unbounded_send(task)
+            .expect("We own the the rx, so this can't fail");
+    }
+
+    async fn next_task(&mut self) -> Option<T> {
+        let mut delay: futures::future::Fuse<_> = match self.scheduled_tasks.peek() {
+            Some(task) => tokio::time::delay_until(task.scheduled_time).fuse(),
+            None => futures::future::Fuse::terminated(),
+        };
+        // wait until either the scheduled time of the peeked task or a next call of add_task
+        futures::select! {
+            _ = delay => {},
+            task = self.on_new_task_rx.next() => {
+                if let Some(task) = task {
+                    let curr_time = time::Instant::now();
+                    let scheduled_task = ScheduledTask::new(curr_time, task, self.initial_delay);
+                    self.scheduled_tasks.push(scheduled_task);
+                } else {
+                    debug!(target: "rmc", "The tasks ended");
+                    return None;
+                }
+            }
+        }
+        let ScheduledTask {
+            scheduled_time,
+            task,
+            delay,
+        } = self.scheduled_tasks.pop().expect("Task must be ready");
+        let scheduled_task = ScheduledTask::new(scheduled_time + delay, task.clone(), 2 * delay);
+        self.scheduled_tasks.push(scheduled_task);
+        Some(task)
+    }
+}
+
+pub struct HashAlreadyExistsError {}
+
+pub struct ReliableMulticast<'a, H: Signable + Hash, MK: MultiKeychain> {
+    hash_states: HashMap<H, PartiallyMultisigned<'a, H, MK>>,
+    network_rx: UnboundedReceiver<Message<H, MK::Signature, MK::PartialMultisignature>>,
+    network_tx: UnboundedSender<(
+        NodeIndex,
+        Message<H, MK::Signature, MK::PartialMultisignature>,
+    )>,
+    keychain: &'a MK,
+    node_count: NodeCount,
+    scheduler: Box<dyn TaskScheduler<Task<H, MK>>>,
+    multisigned_hashes_tx: UnboundedSender<Multisigned<'a, H, MK>>,
+    multisigned_hashes_rx: UnboundedReceiver<Multisigned<'a, H, MK>>,
+}
+
+impl<'a, H: Signable + Hash + Eq + Clone + Debug, MK: MultiKeychain> ReliableMulticast<'a, H, MK> {
+    pub fn new(
+        network_rx: UnboundedReceiver<Message<H, MK::Signature, MK::PartialMultisignature>>,
+        network_tx: UnboundedSender<(
+            NodeIndex,
+            Message<H, MK::Signature, MK::PartialMultisignature>,
+        )>,
+        keychain: &'a MK,
+        node_count: NodeCount,
+        scheduler: impl TaskScheduler<Task<H, MK>> + 'static,
+    ) -> Self {
+        let (multisigned_hashes_tx, multisigned_hashes_rx) = unbounded();
+        ReliableMulticast {
+            hash_states: HashMap::new(),
+            network_rx,
+            network_tx,
+            keychain,
+            node_count,
+            scheduler: Box::new(scheduler),
+            multisigned_hashes_tx,
+            multisigned_hashes_rx,
+        }
+    }
+
+    pub fn start_rmc(&mut self, hash: H) {
+        let indexed_hash = Indexed::new(hash, self.keychain.index());
+        let signed_hash = Signed::sign(indexed_hash, self.keychain);
+        let message = Message::SignedHash(signed_hash.into_unchecked());
+        self.handle_message(message);
+    }
+
+    fn handle_message(&mut self, message: Message<H, MK::Signature, MK::PartialMultisignature>) {
+        let hash = message.hash().clone();
+        if let Some(PartiallyMultisigned::Complete { .. }) = self.hash_states.get(&hash) {
+            return;
+        }
+        match message {
+            Message::MultisignedHash(unchecked) => match unchecked.check_multi(self.keychain) {
+                Ok(multisigned) => {
+                    self.hash_states
+                        .insert(hash, PartiallyMultisigned::Complete { multisigned });
+                }
+                Err(_) => {
+                    debug!(target: "rmc", "Received a hash with a bad multisignature");
+                }
+            },
+            Message::SignedHash(unchecked) => {
+                let signed_hash = match unchecked.check(self.keychain) {
+                    Ok(signed_hash) => signed_hash,
+                    Err(_) => {
+                        debug!(target: "rmc", "Received a hash with a bad signature");
+                        return;
+                    }
+                };
+
+                let new_state = match self.hash_states.remove(&hash) {
+                    None => signed_hash.into_partially_multisigned(self.keychain),
+                    Some(partial) => partial.add_signature(signed_hash, self.keychain),
+                };
+                if let PartiallyMultisigned::Complete { multisigned } = &new_state {
+                    self.multisigned_hashes_tx
+                        .unbounded_send(multisigned.clone())
+                        .unwrap();
+                }
+                self.hash_states.insert(hash.clone(), new_state);
+            }
+        }
+    }
+
+    fn do_task(&self, task: Task<H, MK>) {
+        let Task::BroadcastMessage(message) = task;
+        for recipient in 0..self.node_count.0 {
+            let recipient = NodeIndex(recipient);
+            self.network_tx
+                .unbounded_send((recipient, message.clone()))
+                .expect("Sending message should succeed");
+        }
+    }
+
+    pub fn get_multisigned(&self, hash: &H) -> Option<Multisigned<'a, H, MK>> {
+        match self.hash_states.get(hash)? {
+            PartiallyMultisigned::Complete { multisigned } => Some(multisigned.clone()),
+            _ => None,
+        }
+    }
+
+    pub async fn next_multisigned_hash(&mut self) -> Option<Multisigned<'a, H, MK>> {
+        loop {
+            tokio::select! {
+                multisigned_hash = self.multisigned_hashes_rx.next() => {
+                    return multisigned_hash;
+                }
+
+                incoming_message = self.network_rx.next() => {
+                    if let Some(incoming_message) = incoming_message {
+                        self.handle_message(incoming_message);
+                    } else {
+                        debug!(target: "rmc", "Network connection closed");
+                    }
+                }
+
+                task = self.scheduler.next_task() => {
+                    if let Some(task) = task {
+                        self.do_task(task);
+                    } else {
+                        debug!(target: "rmc", "Tasks ended");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/signed.rs
+++ b/src/signed.rs
@@ -24,9 +24,9 @@ pub trait KeyBox: Index {
 /// multisignature.
 /// Whether a multisignature is complete, can be verified with `[MultiKeychain::is_complete]` method.
 /// The signature and the index passed to the `add_signature` method are required to be valid.
-pub trait PartialMultisignature: Debug + Clone + Encode + Decode {
+pub trait PartialMultisignature: Debug + Clone + Encode + Decode + Send + 'static {
     type Signature: Signature;
-    fn add_signature(&mut self, signature: &Self::Signature, index: NodeIndex);
+    fn add_signature(self, signature: &Self::Signature, index: NodeIndex) -> Self;
 }
 
 /// Extends KeyBox with multisigning functionalities. Allows to verify whether a partial multisignature
@@ -38,8 +38,7 @@ pub trait MultiKeychain: KeyBox {
         signature: &Self::Signature,
         index: NodeIndex,
     ) -> Self::PartialMultisignature;
-    fn is_complete(&self, partial: &Self::PartialMultisignature) -> bool;
-    fn verify_partial(&self, msg: &[u8], partial: &Self::PartialMultisignature) -> bool;
+    fn is_complete(&self, msg: &[u8], partial: &Self::PartialMultisignature) -> bool;
 }
 
 pub trait Signable {
@@ -59,10 +58,24 @@ pub struct UncheckedSigned<T: Signable, S> {
     signature: S,
 }
 
+impl<T: Signable, S: Signature> UncheckedSigned<T, S> {
+    pub(crate) fn as_signable(&self) -> &T {
+        &self.signable
+    }
+}
+
 #[cfg(test)]
 impl<T: Signable, S: Signature> UncheckedSigned<T, S> {
-    pub(crate) fn as_signable(&mut self) -> &mut T {
+    pub(crate) fn as_signable_mut(&mut self) -> &mut T {
         &mut self.signable
+    }
+}
+
+impl<T: Signable, S: Signature> Signable for UncheckedSigned<T, S> {
+    type Hash = Vec<u8>;
+
+    fn hash(&self) -> Self::Hash {
+        self.signature.encode()
     }
 }
 
@@ -72,7 +85,7 @@ pub struct SignatureError<T: Signable, S> {
 }
 
 impl<T: Signable + Index, S: Clone> UncheckedSigned<T, S> {
-    /// Verifies whether the signature matches the key with the given index.
+    /// Verifies whether the signature matches the key with the index as in the signed data.
     pub(crate) fn check<KB: KeyBox<Signature = S>>(
         self,
         key_box: &KB,
@@ -89,14 +102,15 @@ impl<T: Signable + Index, S: Clone> UncheckedSigned<T, S> {
 }
 
 impl<T: Signable, S: Clone> UncheckedSigned<T, S> {
-    pub fn check_partial<MK: MultiKeychain<PartialMultisignature = S>>(
+    /// Verifies whether the signature matches the key with the index as in the signed data.
+    pub(crate) fn check_multi<MK: MultiKeychain<PartialMultisignature = S>>(
         self,
         keychain: &MK,
-    ) -> Result<PartiallyMultisigned<T, MK>, SignatureError<T, S>> {
-        if !keychain.verify_partial(self.signable.hash().as_ref(), &self.signature) {
+    ) -> Result<Multisigned<T, MK>, SignatureError<T, S>> {
+        if !(keychain.is_complete(self.signable.hash().as_ref(), &self.signature)) {
             return Err(SignatureError { unchecked: self });
         }
-        Ok(PartiallyMultisigned {
+        Ok(Multisigned {
             unchecked: self,
             marker: PhantomData,
         })
@@ -141,18 +155,29 @@ impl<'a, T: Signable + Index, KB: KeyBox> Signed<'a, T, KB> {
     pub(crate) fn as_signable(&self) -> &T {
         &self.unchecked.signable
     }
+
+    pub(crate) fn into_unchecked(self) -> UncheckedSigned<T, KB::Signature> {
+        self.unchecked
+    }
 }
 
 impl<'a, T: Signable, MK: MultiKeychain> Signed<'a, Indexed<T>, MK> {
-    fn _into_partially_multisigned(self, key_box: &'a MK) -> PartiallyMultisigned<'a, T, MK> {
+    pub fn into_partially_multisigned(self, keychain: &'a MK) -> PartiallyMultisigned<'a, T, MK> {
         let multisignature =
-            key_box.from_signature(&self.unchecked.signature, self.unchecked.signable.index);
-        PartiallyMultisigned {
-            unchecked: UncheckedSigned {
-                signable: self.unchecked.signable.signable,
-                signature: multisignature,
-            },
-            marker: PhantomData,
+            keychain.from_signature(&self.unchecked.signature, self.unchecked.signable.index);
+        let unchecked = UncheckedSigned {
+            signable: self.unchecked.signable.signable,
+            signature: multisignature,
+        };
+        if keychain.is_complete(unchecked.signable.hash().as_ref(), &unchecked.signature) {
+            PartiallyMultisigned::Complete {
+                multisigned: Multisigned {
+                    unchecked,
+                    marker: PhantomData,
+                },
+            }
+        } else {
+            PartiallyMultisigned::Incomplete { unchecked }
         }
     }
 }
@@ -172,8 +197,12 @@ pub struct Indexed<T: Signable> {
 }
 
 impl<T: Signable> Indexed<T> {
-    pub fn new(signable: T, index: NodeIndex) -> Self {
+    pub(crate) fn new(signable: T, index: NodeIndex) -> Self {
         Indexed { signable, index }
+    }
+
+    pub(crate) fn as_signable(&self) -> &T {
+        &self.signable
     }
 }
 
@@ -192,54 +221,86 @@ impl<T: Signable> Index for Indexed<T> {
 }
 
 #[derive(Debug)]
-pub struct PartiallyMultisigned<'a, T: Signable, MK: MultiKeychain> {
-    unchecked: UncheckedSigned<T, MK::PartialMultisignature>,
-    marker: PhantomData<&'a MK>,
-}
-
 pub struct Multisigned<'a, T: Signable, MK: MultiKeychain> {
     pub unchecked: UncheckedSigned<T, MK::PartialMultisignature>,
     marker: PhantomData<&'a MK>,
 }
 
+impl<'a, T: Signable + Clone, MK: MultiKeychain> Clone for Multisigned<'a, T, MK> {
+    fn clone(&self) -> Self {
+        Multisigned {
+            unchecked: self.unchecked.clone(),
+            marker: self.marker,
+        }
+    }
+}
+
 #[derive(Debug)]
-pub struct IncompleteMultisignatureError<'a, T: Signable, MK: MultiKeychain> {
-    pub partial: PartiallyMultisigned<'a, T, MK>,
+pub(crate) struct IncompleteMultisignatureError<'a, T: Signable, MK: MultiKeychain> {
+    pub(crate) partial: PartiallyMultisigned<'a, T, MK>,
+}
+
+#[derive(Debug)]
+pub enum PartiallyMultisigned<'a, T: Signable, MK: MultiKeychain> {
+    Incomplete {
+        unchecked: UncheckedSigned<T, MK::PartialMultisignature>,
+    },
+    Complete {
+        multisigned: Multisigned<'a, T, MK>,
+    },
 }
 
 impl<'a, T: Signable, MK: MultiKeychain> PartiallyMultisigned<'a, T, MK> {
     pub fn sign(signable: T, keychain: &'a MK) -> Self {
-        let signature = keychain.sign(signable.hash().as_ref());
-        let multisignature = keychain.from_signature(&signature, keychain.index());
-        PartiallyMultisigned {
-            unchecked: UncheckedSigned {
-                signable,
-                signature: multisignature,
-            },
-            marker: PhantomData,
-        }
-    }
-    pub fn add_signature(&mut self, signed: Signed<'a, Indexed<T>, MK>) {
-        if self.unchecked.signable.hash().as_ref() != signed.as_signable().hash().as_ref() {
-            debug!("Tried to add a signature of a different object");
-            return;
-        }
-        self.unchecked
-            .signature
-            .add_signature(&signed.unchecked.signature, signed.as_signable().index);
+        let indexed = Indexed::new(signable, keychain.index());
+        let signed = Signed::sign(indexed, keychain);
+        signed.into_partially_multisigned(keychain)
     }
 
-    fn _try_into_complete(
-        self,
-        keychain: &'a MK,
-    ) -> Result<Multisigned<'a, T, MK>, IncompleteMultisignatureError<'a, T, MK>> {
-        if !keychain.is_complete(&self.unchecked.signature) {
-            return Err(IncompleteMultisignatureError { partial: self });
+    pub fn is_complete(&self) -> bool {
+        match self {
+            PartiallyMultisigned::Incomplete { .. } => false,
+            PartiallyMultisigned::Complete { .. } => true,
         }
-        Ok(Multisigned {
-            unchecked: self.unchecked,
-            marker: PhantomData,
-        })
+    }
+
+    pub fn as_unchecked(&self) -> &UncheckedSigned<T, MK::PartialMultisignature> {
+        match self {
+            PartiallyMultisigned::Incomplete { unchecked } => unchecked,
+            PartiallyMultisigned::Complete { multisigned } => &multisigned.unchecked,
+        }
+    }
+
+    pub fn into_unchecked(self) -> UncheckedSigned<T, MK::PartialMultisignature> {
+        match self {
+            PartiallyMultisigned::Incomplete { unchecked } => unchecked,
+            PartiallyMultisigned::Complete { multisigned } => multisigned.unchecked,
+        }
+    }
+
+    pub fn add_signature(self, signed: Signed<'a, Indexed<T>, MK>, keychain: &'a MK) -> Self {
+        if self.as_unchecked().signable.hash().as_ref() != signed.as_signable().hash().as_ref() {
+            debug!("Tried to add a signature of a different object");
+            return self;
+        }
+        match self {
+            PartiallyMultisigned::Incomplete { mut unchecked } => {
+                unchecked.signature = unchecked
+                    .signature
+                    .add_signature(&signed.unchecked.signature, signed.unchecked.signable.index);
+                if keychain.is_complete(unchecked.signable.hash().as_ref(), &unchecked.signature) {
+                    PartiallyMultisigned::Complete {
+                        multisigned: Multisigned {
+                            unchecked,
+                            marker: PhantomData,
+                        },
+                    }
+                } else {
+                    PartiallyMultisigned::Incomplete { unchecked }
+                }
+            }
+            PartiallyMultisigned::Complete { .. } => self,
+        }
     }
 }
 

--- a/src/testing/unreliable.rs
+++ b/src/testing/unreliable.rs
@@ -25,7 +25,7 @@ mod tests {
                 return;
             }
             if let crate::NetworkData(NetworkDataInner::Units(UnitMessage::NewUnit(us))) = data {
-                let full_unit = &mut us.as_signable();
+                let full_unit = &mut us.as_signable_mut();
                 if full_unit.round() == self.round && full_unit.creator() == self.creator {
                     full_unit.set_round(0);
                 }


### PR DESCRIPTION
A simple implementation of RMC Box.

The struct `ReliableMulticast<'a, H: Signable + Hash, MK: MultiKeychain>` multicasts hashes of the type `H` and provides the public methods:

* `pub fn new(...) -> Self`,
* `pub fn start_rmc(&mut self, hash: H) -> Result<(), HashAlreadyExistsError>`,
* `pub async fn next_multisigned_hash(&mut self) -> Option<Multisigned<'a, H, MK>>`.
In order for the box to progress, the function `next_multisigned_hash` needs to be polled.