### PR TITLE
Enhanced configuration of delays. !! Don't merge before the Network change in aleph-node !!

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,73 @@
+use crate::SessionId;
+use std::sync::Arc;
+use tokio::time::Duration;
+
+use crate::nodes::{NodeCount, NodeIndex};
+
+pub type DelaySchedule = Arc<dyn Fn(usize) -> Duration + Sync + Send + 'static>;
+
+#[derive(Clone)]
+pub struct DelayConfig {
+    //Tick frequency of the Member.
+    pub tick_interval: Duration,
+    //After what delay, we repeat a request for a coord or parents.
+    pub requests_interval: Duration,
+    //f(k) represents the delay between the kth and (k+1)th broadcast.
+    pub unit_broadcast_delay: DelaySchedule,
+    //f(k) represents the delay between creating the kth and (k+1)th unit.
+    pub unit_creation_delay: DelaySchedule,
+}
+
+#[derive(Clone)]
+pub struct Config {
+    pub node_ix: NodeIndex,
+    pub session_id: SessionId,
+    pub n_members: NodeCount,
+    pub delay_config: DelayConfig,
+    //All units (except alerted ones) that are higher by >= rounds_margin then our local round number, are ignored.
+    pub rounds_margin: usize,
+    //Maximum number of units that can be attached to an alert.
+    pub max_units_per_alert: usize,
+    //Maximum allowable round of a unit.
+    pub max_round: usize,
+}
+
+pub(crate) fn exponential_slowdown(
+    t: usize,
+    base_delay: f64,
+    start_exp_delay: usize,
+    exp_base: f64,
+) -> Duration {
+    // This gives:
+    // base_delay, for t <= start_exp_delay,
+    // base_delay * exp_base^(t - start_exp_delay), for t > start_exp_delay.
+    let delay = if t < start_exp_delay {
+        base_delay
+    } else {
+        let power = t - start_exp_delay;
+        base_delay * exp_base.powf(power as f64)
+    };
+    let delay = delay.round() as u64;
+    // the above will make it u64::MAX if it exceeds u64
+    Duration::from_millis(delay)
+}
+
+pub fn default_config(n_members: NodeCount, node_ix: NodeIndex, session_id: SessionId) -> Config {
+    let delay_config = DelayConfig {
+        tick_interval: Duration::from_millis(100),
+        requests_interval: Duration::from_millis(3000),
+        unit_broadcast_delay: Arc::new(|t| exponential_slowdown(t, 4000.0, 0, 2.0)),
+        // 4000, 8000, 16000, 32000, ...
+        unit_creation_delay: Arc::new(|t| exponential_slowdown(t, 500.0, 3000, 1.005)),
+        // 500, 500, 500, ... (till step 3000), 500, 500*1.005, 500*(1.005)^2, 500*(1.005)^3, ..., 10742207 (last step)
+    };
+    Config {
+        node_ix,
+        session_id,
+        n_members,
+        delay_config,
+        rounds_margin: 200,
+        max_units_per_alert: 200,
+        max_round: 5000,
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,8 @@ use std::{fmt::Debug, hash::Hash as StdHash};
 
 use crate::nodes::{NodeCount, NodeIndex, NodeMap};
 
-pub use member::{Config, Member};
+pub use config::{default_config, Config};
+pub use member::Member;
 pub use network::{Network, NetworkData};
 
 mod bft;
@@ -20,6 +21,7 @@ mod network;
 pub mod nodes;
 mod signed;
 pub use signed::*;
+mod config;
 mod terminal;
 mod testing;
 mod units;

--- a/src/testing/mock.rs
+++ b/src/testing/mock.rs
@@ -22,7 +22,8 @@ use std::{
 };
 
 use crate::{
-    member::{Config, NotificationIn, NotificationOut},
+    config::{exponential_slowdown, Config, DelayConfig},
+    member::{NotificationIn, NotificationOut},
     network::NetworkDataInner,
     units::{Unit, UnitCoord},
     DataIO as DataIOT, Hasher, Index, KeyBox as KeyBoxT, Network as NetworkT,
@@ -436,12 +437,23 @@ impl KeyBoxT for KeyBox {
     }
 }
 
-fn gen_config(ix: NodeIndex, n_members: NodeCount) -> Config {
+pub(crate) fn gen_config(node_ix: NodeIndex, n_members: NodeCount) -> Config {
+    let delay_config = DelayConfig {
+        tick_interval: Duration::from_millis(5),
+        requests_interval: Duration::from_millis(50),
+        unit_broadcast_delay: Arc::new(|t| exponential_slowdown(t, 100.0, 1, 3.0)),
+        //100, 100, 300, 900, 2700, ...
+        unit_creation_delay: Arc::new(|t| exponential_slowdown(t, 50.0, usize::MAX, 1.000)),
+        //50, 50, 50, 50, ...
+    };
     Config {
-        node_id: ix,
+        node_ix,
         session_id: 0,
         n_members,
-        create_lag: Duration::from_millis(100),
+        delay_config,
+        rounds_margin: 200,
+        max_units_per_alert: 200,
+        max_round: 5000,
     }
 }
 


### PR DESCRIPTION
Moves global constants to the configuration of Member.
Adds better control on the delays of the protocol: now by default the create delays till round 3000 (out of default 5000 rounds) are 500ms, and from round 3000 on start to exponentially increase (by a factor of 1.005), so that round 5000 is virtually impossible to reach. This mechanism helps as follows:
1) The honest nodes will now never reach the round limit: 5000
2) The protocol becomes more resistant against crashes/network failures, issues with the DataIO (block production, in practice). 